### PR TITLE
Avoid emit without socket server

### DIFF
--- a/src/status.monitor.gateway.ts
+++ b/src/status.monitor.gateway.ts
@@ -30,12 +30,14 @@ export class StatusMonitorGateway implements OnGatewayConnection {
   }
 
   sendMetrics(metrics) {
-    const data = {
-      os: metrics.os[metrics.os.length - 2],
-      responses: metrics.responses[metrics.responses.length - 2],
-      interval: metrics.interval,
-      retention: metrics.retention,
-    };
-    this.server.emit('esm_stats', data);
+    if (this.server) {
+      const data = {
+        os: metrics.os[metrics.os.length - 2],
+        responses: metrics.responses[metrics.responses.length - 2],
+        interval: metrics.interval,
+        retention: metrics.retention,
+      };
+      this.server.emit('esm_stats', data);
+    }
   }
 }


### PR DESCRIPTION
WS server can be injected after first metrics will be sent