### PR TITLE
Add options to websocket gateway

### DIFF
--- a/src/status.monitor.gateway.ts
+++ b/src/status.monitor.gateway.ts
@@ -7,7 +7,10 @@ import {
 import { StatusMonitoringService } from './status.monitoring.service';
 import { Inject, forwardRef } from '@nestjs/common';
 
-@WebSocketGateway()
+const port = process.env.STATUS_MONITOR_WS_PORT ? parseInt(process.env.STATUS_MONITOR_WS_PORT) : 0;
+const namespace = process.env.STATUS_MONITOR_WS_NAMESPACE || '';
+
+@WebSocketGateway(port, { namespace })
 export class StatusMonitorGateway implements OnGatewayConnection {
   @WebSocketServer()
   server;


### PR DESCRIPTION
For situation when you do not want send status information to all connected clients. 
But I'm not sure that this is the right way to configure websocket gateway decorator.